### PR TITLE
Ensure terminating null is included when setting values via RegSetVal…

### DIFF
--- a/EnvVar.cpp
+++ b/EnvVar.cpp
@@ -186,7 +186,7 @@ void EnvVar::paste (std::string const &text)
                   0,
                   REG_EXPAND_SZ,
                   reinterpret_cast<BYTE const *>(value_.c_str()),
-                  value_.length());
+                  value_.length() + 1);
     RegCloseKey(key);
 
     // Notify everyone of the change.
@@ -225,7 +225,7 @@ void EnvVar::set (std::string const &text)
                   0,
                   REG_EXPAND_SZ,
                   reinterpret_cast<const BYTE *>(value_.c_str()),
-                  value_.length());
+                  value_.length() + 1);
     RegCloseKey(key);
 
     // Notify everyone of the change.


### PR DESCRIPTION
…ueEx

Although values set using RegSetValueEx without inclusion of the terminating null in the
"cbData" parameter seem to still get null terminated by the system (based upon inspection
of the binary data in Registry Editor), the MSDN page for RegSetValueEx is quite clear
that the terminating null should be included in "cbData". Indeed, it is already included
in one place in EnvVar.cpp. This change ensures that all calls to RegSetValueEx include
the terminating null in "cbData".

h/t Debra Do